### PR TITLE
Adding node-v16.13.1 for apim-apps builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -152,6 +152,7 @@ RUN \
     && echo "\n" | sh /build/software/java/jdk-6u33-linux-x64.bin \
     && rm /build/software/java/jdk-6u33-linux-x64.bin
 
+# Most probably, No one is use Node 8.x now, Check and remove
 RUN \
     wget -P /build/software/nodejs https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-x64.tar.xz \
     && tar -xvf /build/software/nodejs/node-v8.8.1-linux-x64.tar.xz --directory /build/software/nodejs \
@@ -161,6 +162,13 @@ RUN \
     wget -P /build/software/nodejs https://nodejs.org/dist/v10.16.2/node-v10.16.2-linux-x64.tar.xz \
     && tar -xvf /build/software/nodejs/node-v10.16.2-linux-x64.tar.xz --directory /build/software/nodejs \
     && rm /build/software/nodejs/node-v10.16.2-linux-x64.tar.xz
+
+
+RUN \
+    wget -P /build/software/nodejs https://nodejs.org/dist/v16.13.1/node-v16.13.1-linux-x64.tar.xz \
+    && tar -xvf /build/software/nodejs/node-v16.13.1-linux-x64.tar.xz --directory /build/software/nodejs \
+    && rm /build/software/nodejs/node-v16.13.1-linux-x64.tar.xz
+
 
 RUN wget -P /build/software/go https://dl.google.com/go/go1.10.linux-amd64.tar.gz \
     && tar -xzf /build/software/go/go1.10.linux-amd64.tar.gz --directory /build/software/go && mv /build/software/go/go /build/software/go/go-1.10 && rm /build/software/go/go1.10.linux-amd64.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -152,7 +152,6 @@ RUN \
     && echo "\n" | sh /build/software/java/jdk-6u33-linux-x64.bin \
     && rm /build/software/java/jdk-6u33-linux-x64.bin
 
-# Most probably, No one is use Node 8.x now, Check and remove
 RUN \
     wget -P /build/software/nodejs https://nodejs.org/dist/v8.8.1/node-v8.8.1-linux-x64.tar.xz \
     && tar -xvf /build/software/nodejs/node-v8.8.1-linux-x64.tar.xz --directory /build/software/nodejs \
@@ -162,13 +161,6 @@ RUN \
     wget -P /build/software/nodejs https://nodejs.org/dist/v10.16.2/node-v10.16.2-linux-x64.tar.xz \
     && tar -xvf /build/software/nodejs/node-v10.16.2-linux-x64.tar.xz --directory /build/software/nodejs \
     && rm /build/software/nodejs/node-v10.16.2-linux-x64.tar.xz
-
-
-RUN \
-    wget -P /build/software/nodejs https://nodejs.org/dist/v16.13.1/node-v16.13.1-linux-x64.tar.xz \
-    && tar -xvf /build/software/nodejs/node-v16.13.1-linux-x64.tar.xz --directory /build/software/nodejs \
-    && rm /build/software/nodejs/node-v16.13.1-linux-x64.tar.xz
-
 
 RUN wget -P /build/software/go https://dl.google.com/go/go1.10.linux-amd64.tar.gz \
     && tar -xzf /build/software/go/go1.10.linux-amd64.tar.gz --directory /build/software/go && mv /build/software/go/go /build/software/go/go-1.10 && rm /build/software/go/go1.10.linux-amd64.tar.gz

--- a/bionic.Dockerfile
+++ b/bionic.Dockerfile
@@ -148,6 +148,11 @@ RUN \
     && tar -xvf /build/software/nodejs/node-v12.20.1-linux-x64.tar.xz --directory /build/software/nodejs \
     && rm /build/software/nodejs/node-v12.20.1-linux-x64.tar.xz
 
+RUN \
+    wget -P /build/software/nodejs https://nodejs.org/dist/v16.13.1/node-v16.13.1-linux-x64.tar.xz \
+    && tar -xvf /build/software/nodejs/node-v16.13.1-linux-x64.tar.xz --directory /build/software/nodejs \
+    && rm /build/software/nodejs/node-v16.13.1-linux-x64.tar.xz
+
 RUN wget -P /build/software/go https://dl.google.com/go/go1.10.linux-amd64.tar.gz \
     && tar -xzf /build/software/go/go1.10.linux-amd64.tar.gz --directory /build/software/go && mv /build/software/go/go /build/software/go/go-1.10 && rm /build/software/go/go1.10.linux-amd64.tar.gz
 


### PR DESCRIPTION
## Purpose

- [apim-apps repo](https://github.com/wso2/apim-apps) use npm workspaces which require npm 7.x or above hence adding node 16.x LTS

## Goals

- Fix [jenkins build](https://wso2.org/jenkins/view/platform/job/platform-builds/job/apim-apps/) failure

## Followup work

- As [discussed here](https://github.com/wso2/build-docker/pull/5/files#r315162037) we need to update the jenkins config pointing to node 16
